### PR TITLE
getBucketName bug fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,11 @@ const loadURL = serve({ directory: `${__dirname}/dist` });
 
 	ipcMain.handle("getBucketName", async () => {
 		const { credentials } = await config.get();
+
+		if (!credentials) {
+			return null;
+		}
+
 		return credentials.bucket;
 	});
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ const loadURL = serve({ directory: `${__dirname}/dist` });
 	ipcMain.handle("getBucketName", async () => {
 		const { credentials } = await config.get();
 
-		if (!credentials) {
+		if (typeof credentials !== "object") {
 			return null;
 		}
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -222,9 +222,8 @@ export const store = createStore<State>({
 (async () => {
 	if (await backend.invoke("loginStatus")) {
 		store.commit("login");
+		store.dispatch("getBucketName");
 	}
-
-	store.dispatch("getBucketName");
 })();
 
 export const useStore = () => baseUseStore(key);


### PR DESCRIPTION
Returning null when there's no bucket. Calling the getBucketName function only when a user logs in or is already logged in.