### PR TITLE
New backups get displayed properly

### DIFF
--- a/src/components/Backups.vue
+++ b/src/components/Backups.vue
@@ -236,7 +236,9 @@ const setupBackups = (): Properties => {
 
 	store.dispatch("getSnapshots");
 
-	const snapshots = computed<Snapshot[]>(() => store.state.snapshots === null ? [] : store.state.snapshots);
+	const snapshots = computed<Snapshot[]>(() =>
+		store.state.snapshots === null ? [] : store.state.snapshots
+	);
 
 	const backups = computed<IBackup[]>((): IBackup[] => {
 		const arr: IBackup[] = [];

--- a/src/components/Backups.vue
+++ b/src/components/Backups.vue
@@ -116,6 +116,7 @@
 						<backup
 							v-for="backup in backups"
 							v-bind:backup="backup"
+							:key="backup.id"
 						></backup>
 					</div>
 					<button
@@ -235,9 +236,7 @@ const setupBackups = (): Properties => {
 
 	store.dispatch("getSnapshots");
 
-	const snapshots = computed<Snapshot[]>(() =>
-		store.state.snapshots === null ? [] : store.state.snapshots
-	);
+	const snapshots = computed<Snapshot[]>(() => store.state.snapshots === null ? [] : store.state.snapshots);
 
 	const backups = computed<IBackup[]>((): IBackup[] => {
 		const arr: IBackup[] = [];


### PR DESCRIPTION
Without the key directive on the `backup` child component `backups` was just duplicating the first backup job ever created and adding it to the list to be rendered. This caused the newly added backup to never be displayed to the user unless the app is restarted. 